### PR TITLE
Use reductions to create lazy sequences

### DIFF
--- a/src/main/snergly/algorithms.cljc
+++ b/src/main/snergly/algorithms.cljc
@@ -57,18 +57,16 @@
 ;; have the algorithm name as a name prefix (for example,
 ;; sidewinder-step).
 
-(defn binary-tree-seq* [grid [coord & coords]]
-  (lazy-seq
-    (when coord
-      (let [cell (g/grid-cell grid coord)
-            neighbors (g/cell-neighbors cell [:north :east])
-            next-grid (if (empty? neighbors)
-                        grid
-                        (g/link-cells grid cell (rand-nth neighbors)))]
-        (cons next-grid (binary-tree-seq* (g/begin-step next-grid) coords))))))
+(defn binary-tree-seq* [grid coord]
+  (let [grid (g/begin-step grid)
+        cell (g/grid-cell grid coord)
+        neighbors (g/cell-neighbors cell [:north :east])]
+    (if (empty? neighbors)
+      grid
+      (g/link-cells grid cell (rand-nth neighbors)))))
 
 (defn binary-tree-seq [grid]
-  (binary-tree-seq* (g/begin-step (assoc grid ::g/algorithm-name "binary-tree")) (g/grid-positions grid)))
+  (reductions binary-tree-seq* (assoc grid ::g/algorithm-name "binary-tree") (g/grid-positions grid)))
 
 (defn sidewinder-end-run? [cell]
   (let [on-east-side? (not (g/cell-neighbor cell :east))

--- a/src/main/snergly/algorithms.cljc
+++ b/src/main/snergly/algorithms.cljc
@@ -57,16 +57,16 @@
 ;; have the algorithm name as a name prefix (for example,
 ;; sidewinder-step).
 
-(defn binary-tree-seq* [grid coord]
-  (let [grid (g/begin-step grid)
-        cell (g/grid-cell grid coord)
-        neighbors (g/cell-neighbors cell [:north :east])]
-    (if (empty? neighbors)
-      grid
-      (g/link-cells grid cell (rand-nth neighbors)))))
-
-(defn binary-tree-seq [grid]
-  (reductions binary-tree-seq* (assoc grid ::g/algorithm-name "binary-tree") (g/grid-positions grid)))
+(defn binary-tree-seq
+  ([grid]
+    (reductions binary-tree-seq (assoc grid ::g/algorithm-name "binary-tree") (g/grid-positions grid)))
+  ([grid coord]
+    (let [grid (g/begin-step grid)
+          cell (g/grid-cell grid coord)
+          neighbors (g/cell-neighbors cell [:north :east])]
+      (if (empty? neighbors)
+        grid
+        (g/link-cells grid cell (rand-nth neighbors))))))
 
 (defn sidewinder-end-run? [cell]
   (let [on-east-side? (not (g/cell-neighbor cell :east))


### PR DESCRIPTION
All of the algorithms use `lazy-seq` and `cons` to build a lazy sequence of steps in carving out the maze. That process is a little bit fiddly; at least, it's hard for me to remember what should go where when I'm writing something like that from scratch. 

But the `reductions` function manages all of that for you. It's just like `reduce`, but produces a lazy sequence of all of the intermediate values instead of just the final value. I wasn't aware of `reductions` when I originally wrote all of this code.

This is a draft because so far I've only converted `binary-tree-seq`, as it was the easiest. The others have additional intermediate state they pass from step to step; to work with `reductions` they will have to move that extra state to a field within the grid. (Alternatively, the state value for the reduction could be a tuple of `[grid other-state]` and the code that uses the lazy seq from `reductions` would have to know to map `first` over the sequence before using it. However, I think adding the extra algorithm-specific state to the grid is the better approach; it's part of Clojure's philosophy that maps should have documented required or optional fields for public consumption, but it's perfectly acceptable for code to add extra fields if needed for their own purposes, and consumers should just be prepared to accept and ignore fields that they don't know about.)

There's an additional change that I could also implement while doing this. All of the algorithms come with `alg-seq` and `alg-seq*` function pairs. The unary `alg-seq` function just prepares the grid and then kicks off the process by calling `alg-seq*`, which always takes more than one argument. I suspect I did it that way because the `alg-seq` functions are intended to be called from outside this namespace, but the `alg-seq*` functions should only be called from their corresponding `alg-seq` function. But I think instead it would make more sense to just have the `alg-seq` functions support multiple arities, and have their docstrings only document the unary version. Then the unary version would prepare the grid and call `reductions` to use the binary version.